### PR TITLE
Changing scaling measure inputs

### DIFF
--- a/measures_development/btap_create_necb_prototype_building_scale/measure.rb
+++ b/measures_development/btap_create_necb_prototype_building_scale/measure.rb
@@ -66,6 +66,13 @@ class BTAPCreateNECBPrototypeBuildingScale < OpenStudio::Ruleset::ModelUserScrip
     args << epw_file
 
     #argument for Geometry
+    area_scale_factor = OpenStudio::Ruleset::OSArgument::makeDoubleArgument("x_scale_factor", true)
+    area_scale_factor.setDisplayName("area_scale_factor")
+    area_scale_factor.setDefaultValue(1.0)
+    args << area_scale_factor
+
+=begin
+    #argument for Geometry
     x_scale_factor = OpenStudio::Ruleset::OSArgument::makeDoubleArgument("x_scale_factor", true)
     x_scale_factor.setDisplayName("x_scale_factor")
     x_scale_factor.setDefaultValue(1.0)
@@ -82,7 +89,7 @@ class BTAPCreateNECBPrototypeBuildingScale < OpenStudio::Ruleset::ModelUserScrip
     z_scale_factor.setDisplayName("z_scale_factor")
     z_scale_factor.setDefaultValue(1.0)
     args << z_scale_factor
-
+=end
     return args
   end
 
@@ -100,9 +107,17 @@ class BTAPCreateNECBPrototypeBuildingScale < OpenStudio::Ruleset::ModelUserScrip
     template = runner.getStringArgumentValue('template',user_arguments)
     climate_zone = 'NECB HDD Method'
     epw_file = runner.getStringArgumentValue('epw_file',user_arguments)
+    area_scale_factor = runner.getDoubleArgumentValue('area_scale_factor',user_arguments)
+=begin
     x_scale_factor = runner.getDoubleArgumentValue('x_scale_factor',user_arguments)
     y_scale_factor = runner.getDoubleArgumentValue('y_scale_factor',user_arguments)
     z_scale_factor = runner.getDoubleArgumentValue('z_scale_factor',user_arguments)
+=end
+
+    #Determine x and y scaling from area
+    x_scale_factor = Math.sqrt(area_scale_factor)
+    y_scale_factor = x_scale_factor
+    z_scale_factor = 1.0
 
     # Turn debugging output on/off
     @debug = false    

--- a/measures_development/btap_create_necb_prototype_building_scale/measure.rb
+++ b/measures_development/btap_create_necb_prototype_building_scale/measure.rb
@@ -66,7 +66,7 @@ class BTAPCreateNECBPrototypeBuildingScale < OpenStudio::Ruleset::ModelUserScrip
     args << epw_file
 
     #argument for Geometry
-    area_scale_factor = OpenStudio::Ruleset::OSArgument::makeDoubleArgument("x_scale_factor", true)
+    area_scale_factor = OpenStudio::Ruleset::OSArgument::makeDoubleArgument("area_scale_factor", true)
     area_scale_factor.setDisplayName("area_scale_factor")
     area_scale_factor.setDefaultValue(1.0)
     args << area_scale_factor

--- a/measures_development/btap_create_necb_prototype_building_scale/measure.xml
+++ b/measures_development/btap_create_necb_prototype_building_scale/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>btap_create_necb_prototype_building_scale</name>
   <uid>3e9acd53-8602-4749-a655-7cbbe48e8b30</uid>
-  <version_id>c1a0352a-8793-4d61-9101-1cb6f3e7ffbf</version_id>
-  <version_modified>20180623T220548Z</version_modified>
+  <version_id>20c71a8e-fa42-4bf3-a987-7f9a259af771</version_id>
+  <version_modified>20180625T195702Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BTAPCreateNECBPrototypeBuildingScale</class_name>
   <display_name>BTAPCreateNECBPrototypeBuildingScale</display_name>
@@ -378,23 +378,7 @@
     </argument>
     <argument>
       <name>x_scale_factor</name>
-      <display_name>x_scale_factor</display_name>
-      <type>Double</type>
-      <required>true</required>
-      <model_dependent>false</model_dependent>
-      <default_value>1</default_value>
-    </argument>
-    <argument>
-      <name>y_scale_factor</name>
-      <display_name>y_scale_factor</display_name>
-      <type>Double</type>
-      <required>true</required>
-      <model_dependent>false</model_dependent>
-      <default_value>1</default_value>
-    </argument>
-    <argument>
-      <name>z_scale_factor</name>
-      <display_name>z_scale_factor</display_name>
+      <display_name>area_scale_factor</display_name>
       <type>Double</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
@@ -424,7 +408,7 @@
       <filename>test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>386C3560</checksum>
+      <checksum>16CD92C3</checksum>
     </file>
     <file>
       <version>
@@ -435,7 +419,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>2E63F276</checksum>
+      <checksum>F92460E6</checksum>
     </file>
   </files>
 </measure>

--- a/measures_development/btap_create_necb_prototype_building_scale/measure.xml
+++ b/measures_development/btap_create_necb_prototype_building_scale/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>btap_create_necb_prototype_building_scale</name>
   <uid>3e9acd53-8602-4749-a655-7cbbe48e8b30</uid>
-  <version_id>20c71a8e-fa42-4bf3-a987-7f9a259af771</version_id>
-  <version_modified>20180625T195702Z</version_modified>
+  <version_id>dfca3fd9-127f-4229-a3bf-76737a2ec06d</version_id>
+  <version_modified>20180625T203750Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BTAPCreateNECBPrototypeBuildingScale</class_name>
   <display_name>BTAPCreateNECBPrototypeBuildingScale</display_name>
@@ -377,7 +377,7 @@
       </choices>
     </argument>
     <argument>
-      <name>x_scale_factor</name>
+      <name>area_scale_factor</name>
       <display_name>area_scale_factor</display_name>
       <type>Double</type>
       <required>true</required>
@@ -408,7 +408,7 @@
       <filename>test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>16CD92C3</checksum>
+      <checksum>11EA1976</checksum>
     </file>
     <file>
       <version>
@@ -419,7 +419,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F92460E6</checksum>
+      <checksum>61809518</checksum>
     </file>
   </files>
 </measure>

--- a/measures_development/btap_create_necb_prototype_building_scale/tests/test.rb
+++ b/measures_development/btap_create_necb_prototype_building_scale/tests/test.rb
@@ -23,7 +23,7 @@ class BTAPCreateNECBPrototypeBuildingScale_Test < Minitest::Test
     # test arguments and defaults
     arguments = measure.arguments(model)
     #check number of arguments.
-    assert_equal(6, arguments.size)
+    assert_equal(4, arguments.size)
     #check argument 0
     assert_equal('building_type', arguments[0].name)
     assert_equal('SmallOffice', arguments[0].defaultValueAsString)
@@ -34,6 +34,10 @@ class BTAPCreateNECBPrototypeBuildingScale_Test < Minitest::Test
     assert_equal('epw_file', arguments[2].name)
     assert_equal('CAN_AB_Banff.CS.711220_CWEC2016.epw', arguments[2].defaultValueAsString)
     #check argument 3
+    assert_equal('area_scale_factor', arguments[3].name)
+    assert_equal(1.0, arguments[3].defaultValueAsDouble)
+=begin
+    #check argument 3
     assert_equal('x_scale_factor', arguments[3].name)
     assert_equal(1.0, arguments[3].defaultValueAsDouble)
     #check argument 4
@@ -42,6 +46,7 @@ class BTAPCreateNECBPrototypeBuildingScale_Test < Minitest::Test
     #check argument 5
     assert_equal('z_scale_factor', arguments[5].name)
     assert_equal(1.0, arguments[5].defaultValueAsDouble)
+=end
 
     # set argument values to values and run the measure
     argument_map = OpenStudio::Measure.convertOSArgumentVectorToMap(arguments)
@@ -61,6 +66,12 @@ class BTAPCreateNECBPrototypeBuildingScale_Test < Minitest::Test
     assert(epw_file.setValue('CAN_AB_Banff.CS.711220_CWEC2016.epw'))
     argument_map['epw_file'] = epw_file
 
+    #set argument 4
+    area_scale_factor = arguments[3].clone
+    assert(area_scale_factor.setValue(1.0))
+    argument_map['area_scale_factor'] = x_scale_factor
+
+=begin
     #set argument 3
     x_scale_factor = arguments[3].clone
     assert(x_scale_factor.setValue(1.0))
@@ -75,6 +86,7 @@ class BTAPCreateNECBPrototypeBuildingScale_Test < Minitest::Test
     z_scale_factor = arguments[3].clone
     assert(z_scale_factor.setValue(1.0))
     argument_map['z_scale_factor'] = z_scale_factor
+=end
 
     #run the measure
     measure.run(model, runner, argument_map)

--- a/measures_development/btap_create_necb_prototype_building_scale/tests/test.rb
+++ b/measures_development/btap_create_necb_prototype_building_scale/tests/test.rb
@@ -69,7 +69,7 @@ class BTAPCreateNECBPrototypeBuildingScale_Test < Minitest::Test
     #set argument 4
     area_scale_factor = arguments[3].clone
     assert(area_scale_factor.setValue(1.0))
-    argument_map['area_scale_factor'] = x_scale_factor
+    argument_map['area_scale_factor'] = area_scale_factor
 
 =begin
     #set argument 3


### PR DESCRIPTION
Adjusted inputs to scaling measure so that only an area scaling variable is required rather than x, y, and z scaling.  The x and y scaling are set to the square root of the area scaling variable and z scaling is set to 1.