### PR TITLE
fixes to autotester

### DIFF
--- a/measures/btap_results/tests/test.rb
+++ b/measures/btap_results/tests/test.rb
@@ -42,8 +42,7 @@ class BTAPResults_Test < MiniTest::Unit::TestCase
   # NECB2015 will work after openstudio-standards/tree/nrcan_48
   # has been pulled into nrcan
   @@templates=[
-      "NECB2011",
-      "NECB2015"
+      "NECB2011"
   ]
 
   # Added the template into the path name of the run dir so

--- a/parallel_tests.rb
+++ b/parallel_tests.rb
@@ -1,0 +1,113 @@
+require 'fileutils'
+require 'parallel'
+require 'open3'
+
+TestOutputFolder = File.join(File.dirname(__FILE__), 'local_test_output')
+ProcessorsUsed = (Parallel.processor_count * 2 / 3).floor
+
+class String
+  # colorization
+  def colorize(color_code)
+    "\e[#{color_code}m#{self}\e[0m"
+  end
+
+  def red
+    colorize(31)
+  end
+
+  def green
+    colorize(32)
+  end
+
+  def yellow
+    colorize(33)
+  end
+
+  def blue
+    colorize(34)
+  end
+
+  def pink
+    colorize(35)
+  end
+
+  def light_blue
+    colorize(36)
+  end
+end
+
+
+def write_results(result, test_file)
+  test_file_output = File.join(TestOutputFolder, "#{File.basename(test_file)}_test_output.json")
+  File.delete(test_file_output) if File.exist?(test_file_output)
+  test_result = false
+  if result[2].success?
+    puts "PASSED: #{test_file}".green
+    return true
+  else
+    #store output for failed run.
+    output = {"test" => test_file,
+              "test_result" => test_result,
+              "output" => {
+                  "status" => result[2],
+                  "std_out" => result[0].split(/\r?\n/),
+                  "std_err" => result[1].split(/\r?\n/)
+              }
+    }
+
+
+    #puts test_file_output
+    File.open(test_file_output, 'w') {|f| f.write(JSON.pretty_generate(output))}
+    puts "FAILED: #{test_file_output}".red
+    return false
+  end
+end
+
+class ParallelTests
+
+  def run(file_list)
+    did_all_tests_pass = true
+
+    @full_file_list = nil
+    FileUtils.rm_rf(TestOutputFolder)
+    FileUtils.mkpath(TestOutputFolder)
+
+    # load test files from file.
+    @full_file_list = file_list.shuffle
+
+    puts "Running #{@full_file_list.size} tests suites in parallel using #{ProcessorsUsed} of available cpus."
+    puts "To increase or decrease the ProcessorsUsed, please edit the test/test_run_all_locally.rb file."
+    timings_json = Hash.new()
+    Parallel.each(@full_file_list, in_threads: (ProcessorsUsed), progress: "Progress :") do |test_file|
+      file_name = test_file.gsub(/^.+(openstudio-standards\/test\/)/, '')
+      timings_json[file_name.to_s] = {}
+      timings_json[file_name.to_s]['start'] = Time.now.to_i
+      did_all_tests_pass = false unless write_results(Open3.capture3('bundle', 'exec', "ruby '#{test_file}'"), test_file)
+      timings_json[file_name.to_s]['end'] = Time.now.to_i
+      timings_json[file_name.to_s]['total'] = timings_json[file_name.to_s]['end'] - timings_json[file_name.to_s]['start']
+    end
+=begin
+    #Sometimes the runs fail.
+    #Load failed JSON files from folder local_test_output
+    unless did_all_tests_pass
+      did_all_tests_pass = true
+      failed_runs = []
+      files = Dir.glob("#{File.dirname(__FILE__)}/local_test_output/*.json").select {|e| File.file? e}
+      files.each do |file|
+        data = JSON.parse(File.read(file))
+        failed_runs << data["test"]
+      end
+      puts "These files failed in the initial simulation. This may have been due to computer performance issues. Rerunning failed tests.."
+      Parallel.each(failed_runs, in_threads: (ProcessorsUsed), progress: "Progress :") do |test_file|
+        file_name = test_file.gsub(/^.+(openstudio-standards\/test\/)/, '')
+        timings_json[file_name.to_s] = {}
+        timings_json[file_name.to_s]['start'] = Time.now.to_i
+        did_all_tests_pass = false unless write_results(Open3.capture3('bundle', 'exec', "ruby '#{test_file}'"), test_file)
+        timings_json[file_name.to_s]['end'] = Time.now.to_i
+        timings_json[file_name.to_s]['total'] = timings_json[file_name.to_s]['end'] - timings_json[file_name.to_s]['start']
+      end
+    end
+=end
+    return did_all_tests_pass
+  end
+end

--- a/test_run_all_test_locally.rb
+++ b/test_run_all_test_locally.rb
@@ -4,86 +4,23 @@ require 'parallel'
 require 'open3'
 require 'minitest/autorun'
 require 'json'
-
+require_relative './parallel_tests'
 TestListFile = File.join(File.dirname(__FILE__), 'circleci_tests.txt')
-TestOutputFolder = File.join(File.dirname(__FILE__), 'local_test_output')
-ProcessorsUsed = ( Parallel.processor_count * 2 / 3 ).floor
-
-class String
-  # colorization
-  def colorize(color_code)
-    "\e[#{color_code}m#{self}\e[0m"
-  end
-
-  def red
-    colorize(31)
-  end
-
-  def green
-    colorize(32)
-  end
-
-  def yellow
-    colorize(33)
-  end
-
-  def blue
-    colorize(34)
-  end
-
-  def pink
-    colorize(35)
-  end
-
-  def light_blue
-    colorize(36)
-  end
-end
-
-
-def write_results(result, test_file)
-
-  if result[2].success?
-    test_result = true
-    puts "PASSED: #{test_file}".green
-    return true
-  else
-    output = {"test" => test_file, "test_result" => test_result, "output" => {"status" => result[2], "std_out" => result[0], "std_err" => result[1]}}
-    #puts output
-    test_file_output =  File.join(TestOutputFolder, "#{File.basename(test_file)}_test_output.json")
-    #puts test_file_output
-    File.open(test_file_output, 'w') {|f| f.write(JSON.pretty_generate(output))}
-    puts "FAILED: #{test_file_output}".red
-    return false
-  end
-end
-
 
 class RunAllTests < Minitest::Test
   def test_all()
-
-    @full_file_list = nil
-    FileUtils.rm_rf(TestOutputFolder)
-    FileUtils.mkpath(TestOutputFolder)
-
+    full_file_list = nil
     if File.exist?(TestListFile)
+      puts TestListFile
       # load test files from file.
-      @full_file_list = File.readlines(TestListFile).shuffle
-      puts @full_file_list
+      full_file_list = File.readlines(TestListFile).shuffle
       # Select only .rb files that exist
-      @full_file_list.select! {|item| item.include?('rb') && File.exist?(File.absolute_path("#{item.strip}"))}
-      @full_file_list.map! {|item| File.absolute_path("#{item.strip}")}
+      full_file_list.select! {|item| item.include?('rb') && File.exist?(File.absolute_path("#{item.strip}"))}
+      full_file_list.map! {|item| File.absolute_path("#{item.strip}")}
     else
       puts "Could not find list of files to test at #{TestListFile}"
       return false
     end
-
-    puts "Running #{@full_file_list.size} tests suites in parallel using #{ProcessorsUsed} of available cpus."
-    puts "To increase or decrease the ProcessorsUsed, please edit the test/test_run_all_locally.rb file."
-    Parallel.each(@full_file_list, in_threads: (ProcessorsUsed), progress: "Progress :" ) do |test_file|
-      result = write_results(Open3.capture3('bundle', 'exec', "ruby '#{test_file}'"), test_file)
-      did_all_tests_pass = false unless result == true
-    end
+    assert(ParallelTests.new.run(full_file_list), "Some tests failed please ensure all test pass and tests have been updated to reflect the changes you expect before issuing a pull request")
   end
 end
-


### PR DESCRIPTION
This fixes the autotest as per issue #171 

So the real culprit was testing the NECB2015 when it was not ready for primetime for btapresults.  Fixed test to check 2011. A new task will be created for this. 

Also updated parrellel method to run tests similar to what is being done on standards